### PR TITLE
Disable submit button to avoid multiple clicks whilst waiting

### DIFF
--- a/src/components/NewOpinion.jsx
+++ b/src/components/NewOpinion.jsx
@@ -1,5 +1,6 @@
 import { use, useActionState } from "react";
 import { OpinionsContext } from "../store/opinions-context";
+import Submit from "./Submit";
 
 export function NewOpinion() {
   const { addOpinion } = use(OpinionsContext);
@@ -71,9 +72,7 @@ export function NewOpinion() {
             </ul>
           ))}
 
-        <p className="actions">
-          <button type="submit">Submit</button>
-        </p>
+        <Submit />
       </form>
     </div>
   );

--- a/src/components/Submit.jsx
+++ b/src/components/Submit.jsx
@@ -1,0 +1,13 @@
+import { useFormStatus } from "react-dom";
+
+export default function Submit() {
+  const { pending } = useFormStatus();
+
+  return (
+    <p className="actions">
+      <button type="submit" disabled={pending}>
+        {pending ? "Submitting..." : "Submit"}
+      </button>
+    </p>
+  );
+}


### PR DESCRIPTION
Conditionally render `submit` button as `submitting...`, and disable button when backend has not responded yet. This will prevent user submitting duplicates.